### PR TITLE
Fix: BuildInfo not getting Id from HistoryDAO

### DIFF
--- a/src/main/java/ci/HistoryDAO.java
+++ b/src/main/java/ci/HistoryDAO.java
@@ -309,7 +309,7 @@ public class HistoryDAO {
 			Sender sender = getSender(senderId);
 			List<Commit> commits = getCommitsForHistory(historyId);
 
-			history.add(new BuildInfo(sender, commits,
+			history.add(new BuildInfo(historyId, sender, commits,
 					new BuildInfo.BuildDetails(buildResult, buildLog),
 					new BuildInfo.TestDetails(totalTests, numOfPassedTests, testLog)));
 
@@ -341,7 +341,7 @@ public class HistoryDAO {
 			Sender sender = getSender(senderId);
 			List<Commit> commits = getCommitsForHistory(historyId);
 
-			 return new BuildInfo(sender, commits,
+			 return new BuildInfo(historyId, sender, commits,
 					new BuildInfo.BuildDetails(buildResult, buildLog),
 					new BuildInfo.TestDetails(totalTests, numOfPassedTests, testLog));
 		}

--- a/src/test/java/ci/HistoryDAOTest.java
+++ b/src/test/java/ci/HistoryDAOTest.java
@@ -198,7 +198,11 @@ public class HistoryDAOTest {
 	@Test
 	@DisplayName("Get History that exists")
 	void getHistory_HistoryExists_ReturnsHistory() throws SQLException {
-		BuildInfo buildInfo = historyDAO.getHistory(1);
+		int historyId = 1;
+		BuildInfo buildInfo = historyDAO.getHistory(historyId);
+
+		Assertions.assertThat(buildInfo).isNotNull();
+		Assertions.assertThat(buildInfo.getId()).isEqualTo(historyId);
 
 		ci.PushPayload.Sender sender = buildInfo.getSender();
 		Assertions.assertThat(sender).isNotNull();
@@ -262,6 +266,10 @@ public class HistoryDAOTest {
 		Assertions.assertThat(history).hasSize(2);
 
 		BuildInfo buildInfo = history.get(0);
+
+		Assertions.assertThat(buildInfo).isNotNull();
+		Assertions.assertThat(buildInfo.getId()).isEqualTo(1);
+
 		ci.PushPayload.Sender sender = buildInfo.getSender();
 		Assertions.assertThat(sender).isNotNull();
 		Assertions.assertThat(sender.name()).isEqualTo("johndoe");
@@ -299,7 +307,11 @@ public class HistoryDAOTest {
 		Assertions.assertThat(commits.get(1).url()).isEqualTo("commitUrl2");
 		Assertions.assertThat(commits.get(1).modifiedFiles()).containsExactly("File1.txt", "File2.txt");
 
+
 		buildInfo = history.get(1);
+
+		Assertions.assertThat(buildInfo).isNotNull();
+		Assertions.assertThat(buildInfo.getId()).isEqualTo(2);
 
 		sender = buildInfo.getSender();
 		Assertions.assertThat(sender).isNotNull();


### PR DESCRIPTION
Fixed id field not set in BuildInfo object by HistoryDAO.
Closes #24 